### PR TITLE
Availability Restrictions

### DIFF
--- a/backend/routes/appointments.js
+++ b/backend/routes/appointments.js
@@ -29,9 +29,6 @@ router.get('/appointments', async (req, res) => {
                             username: true,
                         }
                     }
-                },
-                orderBy: {
-                    dateTime: 'asc'
                 }
             })
         } else {
@@ -45,9 +42,6 @@ router.get('/appointments', async (req, res) => {
                             username: true
                         }
                     }
-                },
-                orderBy: {
-                    dateTime: 'asc'
                 }
             })
         }

--- a/backend/routes/providers.js
+++ b/backend/routes/providers.js
@@ -61,9 +61,6 @@ router.get('/providers/:id/availability', async (req, res) => {
             where: { 
                 providerId,
                 status: 'AVAILABLE' 
-            },
-            orderBy: {
-                dateTime: 'asc'  // sorts available appointments in order
             }
         })
 

--- a/frontend/capstone-frontend/src/DashComponents/ProviderAvailability.jsx
+++ b/frontend/capstone-frontend/src/DashComponents/ProviderAvailability.jsx
@@ -15,7 +15,7 @@ function ProviderAvailability() {
 
             if (res.ok) {
                 const data = await res.json()
-                setAvailabilities(data)
+                setAvailabilities(data.sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime)))
             } else {
                 console.error('Failed to fetch available appointments')
             }
@@ -73,12 +73,12 @@ function ProviderAvailability() {
 
     function getLocalDateTime() {
         const dateNow = new Date()
-        // .getTimezoneOffset() returns difference between UTC and local time in minutes, so multiply by 6000 to get milliseconds
+        // .getTimezoneOffset() returns difference between UTC and local time in minutes, so multiply by 60000 to get milliseconds
         const timezoneOffset = dateNow.getTimezoneOffset() * 60000
-        // .getTime() is current time in milliseconds, subtract timezoneOffset to convert the UTC into user's local time 
+        // .getTime() is current time in milliseconds, subtract timezoneOffset to convert the UTC into user's local time
         const localTime = new Date(dateNow.getTime() - timezoneOffset)
         
-        // .toISOString() gives more information than "datetime-local" needs, so slice() to keep only relevant information
+        // .toISOString() gives more information than "datetime-local" needs, so slice() keeps only relevant information
         return localTime.toISOString().slice(0, 16)
     }
 

--- a/frontend/capstone-frontend/src/hooks/useAppointments.jsx
+++ b/frontend/capstone-frontend/src/hooks/useAppointments.jsx
@@ -12,7 +12,7 @@ export function useAppointments() {
             })
             if(res.ok) {
                 const data = await res.json()
-                setAppointments(data)
+                setAppointments(data.sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime)))
                 setStatus('success')
             } else {
                 console.error('Failed to fetch appointments')


### PR DESCRIPTION
## Description
- This PR prevents providers from inputting available appointments that are in the past and availabilities that either already exist or have an appointment booked then. Additionally, when adding availabilities, the list displays the dates in ascending order. In the upcoming appointments tab, both providers and clients see appointments in ascending order as well. This helps to organize the information. 

## Milestones
- Clean up past features

## Test Plan
https://github.com/user-attachments/assets/de0125ff-1e71-4ccf-832d-ccc1cee0f7f1

- Seen in demo is provider cannot set past dates for availabilities, cannot add duplicate availabilities, and cannot add availabilities at the same time a booked appointment starts 
- Availabilities are listed in order as they are added
- Both provider and client dashboards show the appointments listed in ascending order
