### PR TITLE
Fuzzy Search Stretch Feature

### DIFF
--- a/backend/prisma/migrations/20250723234026_add_booking_tracker/migration.sql
+++ b/backend/prisma/migrations/20250723234026_add_booking_tracker/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "bookingsWithProviders" JSONB;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   googleConnected       Boolean         @default(false)
   clientPreferences     ClientPreferences[]
   providerPreferences   ProviderPreferences?
+  bookingsWithProviders Json?
 }
 
 model Service {

--- a/backend/routes/appointments.js
+++ b/backend/routes/appointments.js
@@ -111,6 +111,7 @@ router.put('/appointments/:id/book', async (req, res) => {
             }
         })
 
+        // Keeps track of the amount of times client books with a provider
         let updatedBookingsWithProviders = []
 
         if(user.bookingsWithProviders) {
@@ -300,6 +301,7 @@ router.put('/appointments/:id/cancel', async (req, res) => {
             return res.status(403).json({ error: 'Unauthorized' })
         }
 
+        // If appointment is cancelled, the amount of times client books with provider is decremented
         let updatedBookingsWithProviders = [...appointment.client.bookingsWithProviders]
 
         const existingProvider = updatedBookingsWithProviders.find(provider => 

--- a/backend/routes/appointments.js
+++ b/backend/routes/appointments.js
@@ -300,7 +300,7 @@ router.put('/appointments/:id/cancel', async (req, res) => {
             return res.status(403).json({ error: 'Unauthorized' })
         }
 
-        let updatedBookingsWithProviders = [...user.bookingsWithProviders]
+        let updatedBookingsWithProviders = [...appointment.client.bookingsWithProviders]
 
         const existingProvider = updatedBookingsWithProviders.find(provider => 
             provider.providerId === appointment.providerId
@@ -316,7 +316,7 @@ router.put('/appointments/:id/cancel', async (req, res) => {
             }
 
             await prisma.user.update({
-                where: { id: user.id },
+                where: { id: appointment.clientId },
                 data: {
                     bookingsWithProviders: updatedBookingsWithProviders
                 }

--- a/backend/routes/appointments.js
+++ b/backend/routes/appointments.js
@@ -323,6 +323,8 @@ router.put('/appointments/:id/cancel', async (req, res) => {
                     bookingsWithProviders: updatedBookingsWithProviders
                 }
             })
+        } else {
+            console.log('Provider not found')
         }
 
         // Cancel in Google Calendar for provider

--- a/backend/routes/providers.js
+++ b/backend/routes/providers.js
@@ -2,9 +2,15 @@ const { PrismaClient } = require('../generated/prisma')
 const prisma = new PrismaClient()
 const router = require('express').Router()
 const BONUS_MULTIPLIER = 0.05
+const SIMILARITY_SCORE_WEIGHT = 0.6
+const BOOKINGS_SCORE_WEIGHT = 0.4
 
 // GET all providers
 router.get('/providers', async (req, res) => {
+    if(!req.session.userId) {
+        return res.status(401).json({ error: 'Log in to see providers!' })
+    }
+
     const { search } = req.query
 
     if(!search || search.trim() === '') {
@@ -12,6 +18,13 @@ router.get('/providers', async (req, res) => {
     }
 
     try {
+        const client = await prisma.user.findUnique({
+            where: { id: req.session.userId },
+            select: {
+                bookingsWithProviders: true
+            }
+        })
+
         const providers = await prisma.user.findMany({
             where: { role: 'PROVIDER' },
             select: {
@@ -21,14 +34,40 @@ router.get('/providers', async (req, res) => {
             }
         })
 
-        const providersScored = providers.map(provider => {
+        // Get the similarity score of the input and each provider name
+        const providersSimilarityScore = providers.map(provider => {
             const similarityScore = findSimilarityScore(search.toLowerCase(), provider.name.toLowerCase())
-            return {...provider, similarityScore}
+            return { ...provider, similarityScore }
         })
 
-        const bestMatchedProviders = providersScored
-            .filter(provider => provider.similarityScore >= 0.55) // ignore names with scores below 0.55
-            .sort((a, b) => b.similarityScore - a.similarityScore)
+        // Filter out the names with similarity scores below 0.55
+        const similarProviders = providersSimilarityScore.filter(provider => provider.similarityScore >= 0.55) 
+
+        // Find the provider that the client most frequeuntly books with and the number of booked appointments client has with them 
+        let mostBookedProviderCount = 1
+
+        for (const provider of client.bookingsWithProviders) {
+            if (provider.count > mostBookedProviderCount) {
+                mostBookedProviderCount = provider.count
+            }
+        }
+
+        // Of these filtered names, get the booking score by how frequently they are booked by the client
+        const scoredProviders = similarProviders.map(provider => {
+            const bookingsScore = findBookingsScore(
+                provider.id, 
+                client.bookingsWithProviders, 
+                mostBookedProviderCount
+            )
+            
+            // Compute a total score taking into account similarity score and booking score with varying weights
+            const totalScore = SIMILARITY_SCORE_WEIGHT * provider.similarityScore + BOOKINGS_SCORE_WEIGHT * bookingsScore
+
+            return {...provider, totalScore}
+        })  
+
+        // Sort results by the total score
+        const bestMatchedProviders = scoredProviders.sort((a, b) => b.totalScore - a.totalScore)
 
         res.json(bestMatchedProviders)
     } catch (error) {
@@ -37,7 +76,7 @@ router.get('/providers', async (req, res) => {
     }
 }) 
 
-// Fuzzy Search function
+// Fuzzy Search: Similarity Score Function
 function findSimilarityScore(input, target) {
     let i = 0
     let j = 0
@@ -85,6 +124,17 @@ function findSimilarityScore(input, target) {
     const similarityScore = 1 - cost / maxLength + bonus
 
     return similarityScore
+}
+
+// Fuzzy Search: Scoring providers by how often client book with them
+function findBookingsScore(providerId, bookingsWithProviders, mostBookedProviderCount) {
+    const existingProvider = bookingsWithProviders.find(provider => provider.providerId === providerId)
+    if(!existingProvider) {
+        return 0
+    }
+
+    // Score the provider relative to the most frequently booked provider of the client (value will be from 0 to 1)
+    return existingProvider.count / mostBookedProviderCount 
 }
 
 // GET single provider

--- a/backend/routes/providers.js
+++ b/backend/routes/providers.js
@@ -4,6 +4,7 @@ const router = require('express').Router()
 const BONUS_MULTIPLIER = 0.05
 const SIMILARITY_SCORE_WEIGHT = 0.6
 const BOOKINGS_SCORE_WEIGHT = 0.4
+const SIMILARITY_THRESHOLD = 0.55
 
 // GET all providers
 router.get('/providers', async (req, res) => {
@@ -40,10 +41,10 @@ router.get('/providers', async (req, res) => {
             return { ...provider, similarityScore }
         })
 
-        // Filter out the names with similarity scores below 0.55
-        const similarProviders = providersSimilarityScore.filter(provider => provider.similarityScore >= 0.55) 
+        // Filter out the names with similarity scores below a defined threshold
+        const similarProviders = providersSimilarityScore.filter(provider => provider.similarityScore >= SIMILARITY_THRESHOLD) 
 
-        // Find the provider that the client most frequeuntly books with and the number of booked appointments client has with them 
+        // Find the provider that the client most frequeuntly books with and the number of booked appointments client has with them (defaulting to 1 avoids dividing by 0 issues)
         let mostBookedProviderCount = 1
 
         for (const provider of client.bookingsWithProviders) {

--- a/frontend/capstone-frontend/src/DashComponents/ClientSearchForm.jsx
+++ b/frontend/capstone-frontend/src/DashComponents/ClientSearchForm.jsx
@@ -19,7 +19,9 @@ function ClientSearchForm() {
         setStatus('loading')
 
         try {   
-            const res = await fetch(`${import.meta.env.VITE_API_URL}/providers?search=${encodeURIComponent(query)}`)
+            const res = await fetch(`${import.meta.env.VITE_API_URL}/providers?search=${encodeURIComponent(query)}`, {
+                credentials: 'include'
+            })
 
             await new Promise(resolve => setTimeout(resolve, LOADING_IN_MS))  // Force loading state
             


### PR DESCRIPTION
## Description
- This PR implements a stretch goal for Technical Challenge 2, Fuzzy Search. Previously, search results were ranked by how well they matched the query. Now, the ranking also takes into consideration whether the client books more often with one. So even though a provider's name matches the query better, if the client does not book with them often (when compared to another provider), their score can decrease and rank lower. 
- This required adding a field to the User model recording the amount of times a client booked with a certain provider, adjusting the booking/cancelling routes to account for this, and implementing additional filtering/sorting logic to get the booking frequency score. 
- What's Next: Potentially optimizing this more and additional stretch goals

## Milestones
- TC 2 (Fuzzy Search): Stretch Goal

## Test Plan
https://github.com/user-attachments/assets/f11aa9da-9d6e-40e4-be6c-6135633b08fc
- Input: 'Mathey'
- Client has not booked with Kathy or Matthew => prefers Matthew (more similar)
- Client books more with Kathy than Matthew => prefers Kathy
- Client books more with Matthew => prefers Matthew (but also because of original similarity)

- Screenshot displaying specific cases:
<img width="352" height="939" alt="Screenshot 2025-07-23 at 7 10 00 PM" src="https://github.com/user-attachments/assets/c9d9d8e9-8f47-41a8-a5c3-66e1df01ddc4" />
