### PR TITLE
(Fuzzy Search) Remove Old Providers

### DIFF
--- a/backend/routes/appointments.js
+++ b/backend/routes/appointments.js
@@ -6,6 +6,7 @@ const { google } = require('googleapis')
 
 const S_PER_MINUTE = 60
 const MS_PER_S = 1000
+const MONTH_LIMIT = 3
 
 // GET all appointments 
 router.get('/appointments', async (req, res) => {
@@ -203,11 +204,10 @@ router.put('/appointments/:id/book', async (req, res) => {
 })
 
 function removeOldProviders(bookings) {
-    const today = new Date()
-    const threeMonthsAgo = today.getMonth() - 3
-    const todayThreeMonthsAgo = today.setMonth(threeMonthsAgo)
-
-    return bookings.filter(provider => new Date(provider.lastBookedAt) >= todayThreeMonthsAgo)
+    const threeMonthsAgo = new Date()
+    threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - MONTH_LIMIT)
+    
+    return bookings.filter(provider => new Date(provider.lastBookedAt) >= threeMonthsAgo)
 }
 
 // EDIT single appointment


### PR DESCRIPTION
## Description
- This PR helps to manage the data that holds the booking frequency of providers for a client. Specifically, each time a new appointment is booked, the data filters out any providers that were not booked within the last 3 months. This helps to optimize storage as stale data is removed. 
- What's Next: Further optimization, organizing code 

## Milestones
- Fuzzy Search: Stretch Goal

## Test Plan
https://github.com/user-attachments/assets/ef8f60e4-c2f9-46a5-9a90-f09ad8316996
- Because I cannot wait 3 months for an appointment to expire right now, I decided to manipulate the data currently being stored. I changed the last booked to a time more than 3 months ago. When I booked someone new, the filtering function is called and gets rid of this older provider. 
- You can see providerId = 1 disappears

